### PR TITLE
Adding "gulp" script & Roasted Clefthoof STR fix

### DIFF
--- a/cpp/buffs.cpp
+++ b/cpp/buffs.cpp
@@ -12,7 +12,7 @@ Buff buff_list[] =
   {  13452, {   0,  25,   0, 0, 28, 0,  0,  0,  0,  0,  0, 0 } }, // Elixir of the Mongoose
   {  22831, {   0,  35,   0, 0, 20, 0,  0,  0,  0,  0,  0, 0 } }, // Elixir of Major Agility
   {  27664, {   0,  20,   0, 0, 0, 0,  0,  0,  0,  0,  0, 0 } },  // Grilled Mudfish
-  {  27658, {   0,   0,   0, 0, 0, 0,  0,  0,  0,  0,  0, 0 } },  // Roasted Clefthoof
+  {  27658, {   20,   0,   0, 0, 0, 0,  0,  0,  0,  0,  0, 0 } },  // Roasted Clefthoof
 };
 
 static_vector<Buff> Buffs = buff_list;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   },
   "scripts": {
     "dist": "gulp sass && gulp js",
-    "dev": "gulp --inspect"
+    "dev": "gulp --inspect",
+    "gulp": "gulp"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
"gulp" in script is needed to run gulp on Windows Powershell. Otherwise an error would pop up:
![image](https://user-images.githubusercontent.com/47816228/132656771-ebe41757-6886-491f-bd86-dbb28971aa62.png)
